### PR TITLE
(fix): fix view-model-widget json parse when no data

### DIFF
--- a/src/lib/view-model-widget/view-model-widget-controller.js
+++ b/src/lib/view-model-widget/view-model-widget-controller.js
@@ -55,11 +55,15 @@ module.exports = function ($scope) {
 
         safeUpdateWith($scope.viewModel, function () {
             return {
-                definition: JSON.parse(editorModel.definition),
-                data: JSON.parse(editorModel.data),
-                metadata: JSON.parse(editorModel.metadata)
+                definition: safeParse(editorModel.definition),
+                data: safeParse(editorModel.data),
+                metadata: safeParse(editorModel.metadata)
             }
         });
+    }
+
+    function safeParse(target) {
+        return target ? JSON.parse(target) : {};
     }
 
     function safeUpdateWith(target, sourceProvider) {


### PR DESCRIPTION
In the view-model-widget (controller), when the ViewModel has to JSON parse empty data it fails, usually when there is no metadata. I think it should be fixed here.
